### PR TITLE
cmake: add testing, util lib, version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.19)
-project(polyMpmTest CXX )
+project(polyMpmTest VERSION 0.0.1 LANGUAGES CXX)
+
+include(CTest)
+enable_testing()
 
 function(export_target tgt_name)
   install(TARGETS ${tgt_name} EXPORT ${tgt_name}-target

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,15 +11,22 @@ set(SOURCES
   mesh.cpp
 )
 
-add_library (polyMpmTest-core ${SOURCES})
+add_library(polyMpmTest-core ${SOURCES})
 
-target_include_directories(polyMpmTest-core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+  target_link_libraries(polyMpmTest-core PUBLIC ${MATH_LIBRARY})
+endif()
+
+target_include_directories(polyMpmTest-core INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>)
 target_link_libraries(polyMpmTest-core PUBLIC Kokkos::kokkos)
 target_link_libraries(polyMpmTest-core PRIVATE PkgConfig::NetCDF)
 
 polyMpmTest_export_lib(polyMpmTest-core "${HEADERS}")
 
-add_library (polyMpmTest INTERFACE)
+add_library(polyMpmTest INTERFACE)
 target_link_libraries(polyMpmTest INTERFACE ${polyMpmTest_EXPORTED_TARGETS})
 export_target(polyMpmTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,24 @@
-add_executable (testFoo testFoo.cpp testUtils.cpp)
-add_executable (unitTest unitTest.cpp testUtils.cpp)
-add_executable (timeAssmblyWachspress testTiming.cpp testUtils.cpp)
+add_library(pmtUtils testUtils.cpp)
+target_link_libraries(pmtUtils PRIVATE polyMpmTest)
+target_include_directories(pmtUtils PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
 
-target_link_libraries (testFoo polyMpmTest m)
-target_link_libraries (unitTest polyMpmTest m)
-target_link_libraries (timeAssmblyWachspress polyMpmTest m)
+function(pmt_add_exe exename srcname)
+  if(BUILD_TESTING)
+    add_executable(${exename} ${srcname})
+  else()
+    add_executable(${exename} EXCLUDE_FROM_ALL ${srcname})
+  endif()
+  target_link_libraries (${exename} polyMpmTest pmtUtils)
+  install(TARGETS ${exename} DESTINATION bin)
+endfunction()
 
-install(TARGETS testFoo DESTINATION bin)
-install(TARGETS timeAssmblyWachspress DESTINATION bin)
+pmt_add_exe(testFoo testFoo.cpp)
+pmt_add_exe(unitTest unitTest.cpp)
+pmt_add_exe(timeAssmblyWachspress testTiming.cpp)
 
-#enable_testing()
-
-add_test(
-    unit_test unitTest
-    )
-add_test(
-    test_watchpress testFoo
-    )
+add_test(NAME unit_test COMMAND ./unitTest)
+add_test(NAME test_watchpress COMMAND ./testFoo)
+add_test(NAME test_timing COMMAND ./timeAssmblyWachspress 5)


### PR DESCRIPTION
This PR adds some CMake improvements:

- creates a `util` library in the `test` dir
- CTest testing
- function to add new executables (reduces repeated calls to `target_link_libraries` etc.)
- adds a version number