### PR TITLE
assert macro that works with release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,14 @@ find_package(Kokkos REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(NetCDF REQUIRED IMPORTED_TARGET netcdf>=4.7.3)
 
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+# Set a default build type if none was specified
+# from: https://www.kitware.com/cmake-and-the-default-build-type/
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+    STRING "Choose the type of build." FORCE)
 endif()
-
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 set(CMAKE_CXX_FLAGS "-Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(HEADERS
 
 set(SOURCES
   mesh.cpp
+  utils.cpp
 )
 
 add_library (polyMpmTest-core ${SOURCES})

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,6 @@
+#include "utils.hpp"
+
+void PMT_Assert_Fail(const char* msg) {
+  fprintf(stderr, "%s", msg);
+  abort();
+}

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -14,8 +14,21 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-
 #include <netcdf.h>
+
+//assert borrowed from scorec/core/pcu/pcu_util.h
+void PMT_Assert_Fail(const char* msg) __attribute__ ((noreturn));
+
+#define PMT_ALWAYS_ASSERT(cond)                   \
+  do {                                            \
+    if (! (cond)) {                               \
+      char omsg[2048];                            \
+      sprintf(omsg, "%s failed at %s + %d \n",    \
+        #cond, __FILE__, __LINE__);               \
+      PMT_Assert_Fail(omsg);                      \
+    }                                             \
+  } while (0)
+
 namespace polyMpmTest{
 
 class Vector2;

--- a/test/unitTest.cpp
+++ b/test/unitTest.cpp
@@ -14,29 +14,29 @@ int main() {
     auto v = polyMpmTest::Vector2();
     v[0] = 1;
     v[1] = 2;
-    assert(v[0] == 1);
-    assert(v[1] == 2);
+    PMT_ALWAYS_ASSERT(v[0] == 1);
+    PMT_ALWAYS_ASSERT(v[1] == 2);
 //  test Vector operator
     auto v1 = polyMpmTest::Vector2(1,2);
     auto v2 = polyMpmTest::Vector2(3,4);
     auto v3 = v1 + v2;
-    assert(v3[0] == 4);
-    assert(v3[1] == 6);
+    PMT_ALWAYS_ASSERT(v3[0] == 4);
+    PMT_ALWAYS_ASSERT(v3[1] == 6);
     auto v4 = v1 - v2;
-    assert(v4[0] == -2);
-    assert(v4[1] == -2);
+    PMT_ALWAYS_ASSERT(v4[0] == -2);
+    PMT_ALWAYS_ASSERT(v4[1] == -2);
     auto v5 = v1 * 2;
-    assert(v5[0] == 2);
-    assert(v5[1] == 4);
+    PMT_ALWAYS_ASSERT(v5[0] == 2);
+    PMT_ALWAYS_ASSERT(v5[1] == 4);
     auto v6 = -v1;
-    assert(v6[0] == -1);
-    assert(v6[1] == -2);
+    PMT_ALWAYS_ASSERT(v6[0] == -1);
+    PMT_ALWAYS_ASSERT(v6[1] == -2);
     auto v7 = v1.dot(v2);
-    assert(v7 == 11);
+    PMT_ALWAYS_ASSERT(v7 == 11);
     auto v8 = v1.cross(v2);
-    assert(v8 == -2);
+    PMT_ALWAYS_ASSERT(v8 == -2);
     auto v9 = v1.magnitude();
-    assert(v9 - sqrt(5) < 1e-6);  
+    PMT_ALWAYS_ASSERT(v9 - sqrt(5) < 1e-6);
 
     //run assembly and test Wachpress
     Kokkos::initialize();{
@@ -44,8 +44,8 @@ int main() {
         auto MPMTest = initTestMPM(mTest);
         
         auto meshFromMPM = MPMTest.getMesh();
-        assert(meshFromMPM.getNumVertices() == 19);
-        assert(meshFromMPM.getNumElements() == 10);
+        PMT_ALWAYS_ASSERT(meshFromMPM.getNumVertices() == 19);
+        PMT_ALWAYS_ASSERT(meshFromMPM.getNumElements() == 10);
         
         polyMpmTest::assembly(MPMTest);
         interpolateWachpress(MPMTest);              


### PR DESCRIPTION
This PR adds a macro for assertions that work regardless of the `CMAKE_BUILD_TYPE` setting.  Normal `assert(...)` calls are not enabled when `CMAKE_BUILD_TYPE=Release` (or another variant that defines `NDEBUG`) [[1](https://en.cppreference.com/w/c/error/assert)].